### PR TITLE
Changes required to get this working

### DIFF
--- a/helpers/snap-env
+++ b/helpers/snap-env
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PATH=$SNAP/bin:$SNAP/usr/bin:$SNAP/usr/local/bin:$PATH
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,12 @@ grade: devel
 confinement: classic
 
 apps:
-  tst:
+  unwrapped:
     command: bin/tst
+  wrapped:
+    command: bin/snap-env $SNAP/bin/tst
+  tst:  # default command (same name as snap)
+    command: bin/snap-env $SNAP/bin/tst
 
 parts:
   tst:
@@ -18,3 +22,6 @@ parts:
     parse-info: ['setup.py']
     requirements:
       - requirements.txt
+    override-build: |
+      snapcraftctl build
+      cp helpers/snap-env $SNAPCRAFT_PART_INSTALL/bin


### PR DESCRIPTION
You can compare the wrapped and unwrapped behavior by calling `tst.wrapped` and `tst.unwrapped`, respectively.  Just calling `tst` will get the wrapped (working) behavior by default.